### PR TITLE
Improve news analysis and output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore generated analysis output
+radar_chart.png
+radar_chart_base64.txt
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository provides a simple script to collect global energy news using [Ne
 - Python 3.8+
 - `requests`
 - `pandas`
+- `sentence-transformers`
 - A NewsAPI API key
 
 ## Usage
@@ -30,3 +31,21 @@ python main.py
 ```
 
 The script will fetch news from July 5 to July 8, 2025 related to global energy, clean energy, traditional energy and energy policy. Results are stored in `energy_news.csv`.
+
+## Analyzing the News
+
+After running `main.py`, analyze the articles and generate a radar chart showing political intensity, economic drive, energy relevance and China correlation:
+
+```bash
+python analyze_news.py
+```
+
+The script uses a transformer model to gauge political, economic, energy and
+China-related relevance. A radar chart is created and encoded to base64 text in
+`radar_chart_base64.txt`.
+
+To view the chart as an image:
+
+```bash
+base64 -d radar_chart_base64.txt > radar_chart.png
+```

--- a/analyze_news.py
+++ b/analyze_news.py
@@ -1,0 +1,71 @@
+import base64
+from io import BytesIO
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+from sentence_transformers import SentenceTransformer, util
+
+# Load dataset
+df = pd.read_csv('energy_news.csv')
+
+# Combine title and summary for model analysis
+def combine_text(row):
+    title = str(row.get("title", ""))
+    summary = str(row.get("summary", ""))
+    return f"{title} {summary}".strip()
+
+texts = df.apply(combine_text, axis=1).tolist()
+
+# Use a transformer model to embed the articles and category anchors
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+# Article embeddings
+embeddings = model.encode(texts, convert_to_tensor=True)
+
+# Anchor texts describing each category
+anchors = {
+    "Political": "government policy regulation law congress president diplomacy",
+    "Economic": "economy market business investment finance industry trade gdp",
+    "Energy": "energy renewable clean gas oil solar wind power grid battery",
+    "China": "china chinese beijing shanghai xi huawei sino technology economy",
+}
+
+# Encode anchor texts
+anchor_embeds = {c: model.encode(t, convert_to_tensor=True) for c, t in anchors.items()}
+
+# Calculate mean cosine similarity between articles and each anchor
+scores = {}
+for cat, anchor_emb in anchor_embeds.items():
+    sim = util.cos_sim(embeddings, anchor_emb)
+    scores[cat] = float(sim.mean())
+
+# Normalize scores
+values = np.array(list(scores.values()), dtype=float)
+min_val = values.min()
+values = values - min_val
+values_normalized = values / values.sum() if values.sum() != 0 else values
+
+# Radar chart setup
+labels = list(scores.keys())
+num_labels = len(labels)
+angles = np.linspace(0, 2 * np.pi, num_labels, endpoint=False).tolist()
+values_plot = values_normalized.tolist()
+values_plot += values_plot[:1]
+angles += angles[:1]
+
+fig, ax = plt.subplots(subplot_kw=dict(polar=True))
+ax.plot(angles, values_plot, 'o-', linewidth=2)
+ax.fill(angles, values_plot, alpha=0.25)
+ax.set_thetagrids(np.degrees(angles[:-1]), labels)
+ax.set_ylim(0, values_normalized.max() * 1.1)
+ax.set_title('Energy News Analysis')
+plt.tight_layout()
+
+# Save chart to a base64 text file to avoid binary files in the repository
+buf = BytesIO()
+plt.savefig(buf, format='png')
+b64_data = base64.b64encode(buf.getvalue()).decode('utf-8')
+with open('radar_chart_base64.txt', 'w') as f:
+    f.write(b64_data)
+print('Radar chart encoded to radar_chart_base64.txt')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 requests
 pandas
+numpy
+matplotlib
+sentence-transformers


### PR DESCRIPTION
## Summary
- remove binary radar image and ignore generated files
- analyze news articles with a transformer model instead of keyword counts
- output radar chart as base64 text
- document usage and new dependency

## Testing
- `pip install -r requirements.txt`
- `python analyze_news.py`

------
https://chatgpt.com/codex/tasks/task_e_687df12f163c8324b55d04b927b0da4b